### PR TITLE
Truncate spider name and average crawl speed

### DIFF
--- a/lib/crawly_ui_web/live/job_live.ex
+++ b/lib/crawly_ui_web/live/job_live.ex
@@ -11,6 +11,8 @@ defmodule CrawlyUIWeb.JobLive do
   end
 
   def mount(params, _session, socket) do
+    Manager.update_all_jobs()
+
     page = Map.get(params, "page", 1)
     spider = Map.get(params, "spider", nil)
 

--- a/lib/crawly_ui_web/templates/item/index.html.leex
+++ b/lib/crawly_ui_web/templates/item/index.html.leex
@@ -3,31 +3,32 @@
 <!-- The form -->
 <form phx-submit="search">
   <%= if @search do %>
-    <div class="column"><input type="text" placeholder="<%= @search %>" name="search"></div>
+  <div class="column"><input type="text" placeholder="<%= @search %>" name="search"></div>
   <% else %>
-    <div class="column"><input type="text" placeholder="Search" name="search"></div>
+  <div class="column"><input type="text" placeholder="Search" name="search"></div>
   <% end %>
-   <button type="submit"><i class="fa fa-search"></i></button>
+  <button type="submit"><i class="fa fa-search"></i></button>
 </form>
 <%= for item <- @rows do %>
-  <table class="w3-table-all card">
-  <tbody><tr>
-    <th>Item</th>
-    <th>Discovery time: <%= item.inserted_at %>
-      <%= case Map.get(item.data, "url") do  %>
+<table class="w3-table-all card">
+  <tbody>
+    <tr>
+      <th>Item</th>
+      <th>Discovery time: <%= item.inserted_at %>
+        <%= case Map.get(item.data, "url") do  %>
         <% nil -> %> <%= "" %>
-        <%_url -> %>  <a href="#" phx-click="show_item" phx-value-job=<%= @job_id %> phx-value-item=<%= item.id %>> Preview </a>
-      <% end %>
-    </th>
-  </tr>
+        <%_url -> %> <a href="#" phx-click="show_item" phx-value-job=<%= @job_id %> phx-value-item=<%= item.id %>> Preview </a>
+        <% end %>
+      </th>
+    </tr>
 
-  <%= for {field_name, field_value} <- item.data do %>
-  <tr>
-    <td class="w"><b><%= field_name %></b></td>
-    <td class="c"><%= raw render_field_value(field_name, field_value) %></td>
-  </tr>
-  <% end %>
+    <%= for {field_name, field_value} <- item.data do %>
+    <tr>
+      <td class="w"><b><%= field_name %></b></td>
+      <td class="c"><%= raw render_field_value(field_name, field_value) %></td>
+    </tr>
+    <% end %>
   </tbody>
-  </table>
+</table>
 <% end %>
- <%= raw pagination_links(@page, @total_pages) %>
+<%= raw pagination_links(@page, @total_pages) %>

--- a/lib/crawly_ui_web/templates/job/index.html.leex
+++ b/lib/crawly_ui_web/templates/job/index.html.leex
@@ -29,9 +29,9 @@
         <tr>
           <td>
            <%= if @live_action == :spider do %>
-           <%= live_job.spider %>
+           <%= raw render_spider_name(live_job.spider) %>
            <% else %>
-          <a href="#" phx-click="show_spider" phx-value-spider=<%= live_job.spider %>><%= live_job.spider %></a></td>
+          <a href="#" phx-click="show_spider" phx-value-spider=<%= live_job.spider %>><%= raw render_spider_name(live_job.spider) %></a></td>
            <% end %>
           <td><%= live_job.node %></td>
           <td>
@@ -40,7 +40,7 @@
 
           <td><%= live_job.state %></td>
           <td><%= live_job.inserted_at %></td>
-          <td><%= live_job.crawl_speed || "-" %> items/min</td>
+          <td><%= live_job.crawl_speed %> items/min</td>
           <td><%= raw render_run_time(live_job.run_time) %></td>
           <td> <%= raw render_button(live_job) %></td>
         </tr>

--- a/lib/crawly_ui_web/templates/job/pick_spider.html.leex
+++ b/lib/crawly_ui_web/templates/job/pick_spider.html.leex
@@ -5,11 +5,10 @@
 <form phx-submit="schedule_spider">
   <div class="row">
     <div class="column">
-        <input name="node" type="hidden" value="<%= @node %>">
        <label for="inputState">Spider</label>
        <select name="spider" class="form-control">
           <%= for spider <- @spiders do %>
-          <option> <%= spider %> </option>
+          <option value="<%= spider%>"><%= raw render_spider_name(spider) %></option>
           <% end %>
        </select>
        <div class="column"><%= submit "Schedule" %></div>

--- a/lib/crawly_ui_web/views/job_view.ex
+++ b/lib/crawly_ui_web/views/job_view.ex
@@ -7,8 +7,18 @@ defmodule CrawlyUIWeb.JobView do
   def title(:spider, spider) do
     """
     <h1>Spider</h1>
-    <h2>#{spider}</h2>
+    <h2>#{render_spider_name(spider)}</h2>
     """
+  end
+
+  def render_spider_name(spider) when is_atom(spider) do
+    spider |> to_string() |> render_spider_name()
+  end
+
+  def render_spider_name(spider) when is_binary(spider) do
+    spider
+    |> String.split(".")
+    |> List.last()
   end
 
   def render_run_time(run_time) do
@@ -27,14 +37,14 @@ defmodule CrawlyUIWeb.JobView do
   end
 
   def render_button(%{state: "running", spider: spider} = job) do
-    "<button data-confirm=\"Do you really want to cancel running spider #{spider}?\" phx-click=cancel phx-value-job=#{
-      job.id
-    }>Cancel</button>"
+    "<button data-confirm=\"Do you really want to cancel running spider #{
+      render_spider_name(spider)
+    }?\" phx-click=cancel phx-value-job=#{job.id}>Cancel</button>"
   end
 
   def render_button(%{spider: spider, items_count: items_count} = job) do
-    "<button data-confirm=\"This will delete this job of spider #{spider} and all #{items_count} item(s). Are you sure?\" phx-click=delete phx-value-job=#{
-      job.id
-    }>Delete</button>"
+    "<button data-confirm=\"This will delete this job of spider #{render_spider_name(spider)} and all #{
+      items_count
+    } item(s). Are you sure?\" phx-click=delete phx-value-job=#{job.id}>Delete</button>"
   end
 end

--- a/test/crawly_ui/manager_test.exs
+++ b/test/crawly_ui/manager_test.exs
@@ -317,7 +317,7 @@ defmodule CrawlyUi.ManagerTest do
     assert %Job{items_count: 6, crawl_speed: 1, run_time: 6} = Repo.get(Job, job_1.id)
     assert %Job{items_count: 4, crawl_speed: 4, run_time: 4} = Repo.get(Job, job_2.id)
     assert %Job{items_count: 0, crawl_speed: 0, run_time: 0} = Repo.get(Job, job_3.id)
-    assert %Job{items_count: 3, crawl_speed: 3, run_time: 2} = Repo.get(Job, job_4.id)
+    assert %Job{items_count: 3, crawl_speed: 2, run_time: 2} = Repo.get(Job, job_4.id)
   end
 
   test "get_job_by_tag/1" do

--- a/test/crawly_ui_web/views/item_view_test.exs
+++ b/test/crawly_ui_web/views/item_view_test.exs
@@ -29,7 +29,7 @@ defmodule CrawlyUIWeb.ItemViewTest do
       rendered_string = render_to_string(CrawlyUIWeb.ItemView, "index.html", params)
 
       assert rendered_string =~
-               "<td class=\"w\"><b>field_1</b></td>\n    <td class=\"c\">data_1</td>"
+               "<td class=\"w\"><b>field_1</b></td>\n      <td class=\"c\">data_1</td>"
 
       # test render image
       assert rendered_string =~ "<td class=\"c\"><img width='150px' src='image_1_src' /></td>"
@@ -39,18 +39,18 @@ defmodule CrawlyUIWeb.ItemViewTest do
                "<td class=\"c\"><a target='blank' href='http://example_1.com'>http://example_1.com</a></td>"
 
       assert rendered_string =~
-               "<th>Discovery time: #{item_1.inserted_at}\n  <a href=\"#\" phx-click=\"show_item\" phx-value-job=#{
+               "<th>Discovery time: #{item_1.inserted_at}\n <a href=\"#\" phx-click=\"show_item\" phx-value-job=#{
                  job_id
                } phx-value-item=#{item_1.id}> Preview </a>"
 
       assert rendered_string =~
-               "<td class=\"w\"><b>field_1</b></td>\n    <td class=\"c\">data_2</td>"
+               "<td class=\"w\"><b>field_1</b></td>\n      <td class=\"c\">data_2</td>"
 
       assert rendered_string =~
                "<td class=\"c\"><a target='blank' href='https://example_2.com'>https://example_2.com</a></td>"
 
       assert rendered_string =~
-               "<th>Discovery time: #{item_2.inserted_at}\n  <a href=\"#\" phx-click=\"show_item\" phx-value-job=#{
+               "<th>Discovery time: #{item_2.inserted_at}\n <a href=\"#\" phx-click=\"show_item\" phx-value-job=#{
                  job_id
                } phx-value-item=#{item_2.id}> Preview </a>"
 

--- a/test/crawly_ui_web/views/job_view_test.exs
+++ b/test/crawly_ui_web/views/job_view_test.exs
@@ -41,4 +41,53 @@ defmodule CrawlyUIWeb.JobViewTest do
            ) =~
              "1.5 hours"
   end
+
+  test "render spider name" do
+    job_1 = insert_job(%{spider: "Elixir.Spider.Test"})
+    job_2 = insert_job(%{spider: "Spider.Test"})
+    job_3 = insert_job(%{spider: "Test"})
+
+    view =
+      render_to_string(CrawlyUIWeb.JobView, "index.html",
+        total_pages: 1,
+        live_action: :index,
+        page: 1,
+        spider: nil,
+        rows: [job_1, job_2, job_3]
+      )
+
+    assert view =~ ">Test</a>"
+    refute view =~ ">Spider.Test</a>"
+    refute view =~ ">Elixir.Spider.Test</a>"
+  end
+
+  test "render cancel button" do
+    job = insert_job(%{spider: "Elixir.Spider.Test", state: "running"})
+
+    assert render_to_string(CrawlyUIWeb.JobView, "index.html",
+             total_pages: 1,
+             live_action: :index,
+             page: 1,
+             spider: nil,
+             rows: [job]
+           ) =~
+             "<button data-confirm=\"Do you really want to cancel running spider Test?\" phx-click=cancel phx-value-job=#{
+               job.id
+             }>Cancel</button></td>"
+  end
+
+  test "render delete button" do
+    job = insert_job(%{spider: "Elixir.Spider.Test", state: "stopped", items_count: 100})
+
+    assert render_to_string(CrawlyUIWeb.JobView, "index.html",
+             total_pages: 1,
+             live_action: :index,
+             page: 1,
+             spider: nil,
+             rows: [job]
+           ) =~
+             "<button data-confirm=\"This will delete this job of spider Test and all 100 item(s). Are you sure?\" phx-click=delete phx-value-job=#{
+               job.id
+             }>Delete</button>"
+  end
 end


### PR DESCRIPTION
Address issues:
 #26 by updating all jobs when page is refreshed (at `mount`). Updated the crawl_speed function in Manager to update the crawl speed when job is not running 

#27 Change spider name to a shorter text, basically take the last part of the module as module name. 

