### PR TITLE
#24 Spiders page

### DIFF
--- a/lib/crawly_ui/manager.ex
+++ b/lib/crawly_ui/manager.ex
@@ -80,6 +80,9 @@ defmodule CrawlyUI.Manager do
     |> Repo.paginate(params)
   end
 
+  @doc """
+  List only running jobs
+  """
   def list_running_jobs(params \\ []) do
     Job
     |> where([j], j.state == "running")
@@ -173,6 +176,15 @@ defmodule CrawlyUI.Manager do
     Enum.map(items, &delete_item/1)
   end
 
+  @doc """
+  Make rpc call through Spider Manager to close spider. Depending on the reply, update the Job state accordingly.
+
+  ## Examples
+
+      iex> cancel_running_job(job)
+      {:ok, %Job{state: "cancelled"}}
+
+  """
   def cancel_running_job(job) do
     state =
       case SpiderManager.close_job_spider(job) do
@@ -223,7 +235,7 @@ defmodule CrawlyUI.Manager do
   end
 
   @doc """
-  Returns crawl speed time of the given job
+  Returns crawl speed time of the given job. Returns average crawl speed if the job is not running
 
   ## Examples
 

--- a/lib/crawly_ui/manager.ex
+++ b/lib/crawly_ui/manager.ex
@@ -163,6 +163,23 @@ defmodule CrawlyUI.Manager do
     Enum.map(items, &delete_item/1)
   end
 
+  def cancel_running_job(job) do
+    state =
+      case SpiderManager.close_job_spider(job) do
+        {:ok, :stopped} ->
+          "cancelled"
+
+        {:error, :nodedown} ->
+          "node down"
+
+        _ ->
+          "stopped"
+      end
+
+    crawl_speed = crawl_speed(job)
+    update_job(job, %{state: state, crawl_speed: crawl_speed})
+  end
+
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking job changes.
 

--- a/lib/crawly_ui/manager.ex
+++ b/lib/crawly_ui/manager.ex
@@ -87,6 +87,16 @@ defmodule CrawlyUI.Manager do
   end
 
   @doc """
+  List recent jobs that are not running
+  """
+  def list_recent_jobs() do
+    Job
+    |> where([j], not (j.state == "running"))
+    |> order_by(desc: :inserted_at)
+    |> Repo.paginate(page: 1, page_size: 5)
+  end
+
+  @doc """
   Gets a single job.
 
   Raises `Ecto.NoResultsError` if the Job does not exist.

--- a/lib/crawly_ui_web/live/job_live.ex
+++ b/lib/crawly_ui_web/live/job_live.ex
@@ -2,9 +2,6 @@ defmodule CrawlyUIWeb.JobLive do
   use Phoenix.LiveView
 
   alias CrawlyUI.Manager
-  alias CrawlyUI.SpiderManager
-
-  import Ecto.Query
 
   def render(assigns) do
     template = template(assigns.live_action)
@@ -105,7 +102,7 @@ defmodule CrawlyUIWeb.JobLive do
 
     case socket.assigns.live_action do
       :index ->
-        %{entries: recent_rows} = get_recent_jobs()
+        %{entries: recent_rows} = Manager.list_recent_jobs()
 
         assign(socket,
           rows: rows,
@@ -123,17 +120,10 @@ defmodule CrawlyUIWeb.JobLive do
     if connected?(socket), do: Process.send_after(self(), state, time)
   end
 
+  # List only running jobs and limit for page size of 5 for index, else list all jobs and default page size for all jobs view
   defp list_jobs(:index, page), do: Manager.list_running_jobs(page: page, page_size: 5)
   defp list_jobs(:show, page), do: Manager.list_jobs(page: page)
 
-  defp get_recent_jobs() do
-    Manager.Job
-    |> where([j], not (j.state == "running"))
-    |> order_by(desc: :inserted_at)
-    |> CrawlyUI.Repo.paginate(page: 1, page_size: 5)
-  end
-
   defp template(:index), do: "index.html"
   defp template(:show), do: "show.html"
-  defp template(:spider), do: "spider.html"
 end

--- a/lib/crawly_ui_web/live/job_live.ex
+++ b/lib/crawly_ui_web/live/job_live.ex
@@ -16,30 +16,11 @@ defmodule CrawlyUIWeb.JobLive do
     Manager.update_all_jobs()
 
     page = Map.get(params, "page", 1)
-    spider = Map.get(params, "spider", nil)
-
-    %{
-      entries: rows,
-      page_number: page_number,
-      total_pages: total_pages
-    } = list_jobs(socket.assigns.live_action, spider, page)
 
     socket =
-      case socket.assigns.live_action do
-        :index ->
-          %{entries: recent_rows} = get_recent_jobs()
-
-          assign(socket,
-            rows: rows,
-            page: page_number,
-            spider: spider,
-            total_pages: total_pages,
-            recent_rows: recent_rows
-          )
-
-        _ ->
-          assign(socket, rows: rows, spider: spider, page: page_number, total_pages: total_pages)
-      end
+      socket
+      |> assign(page: page)
+      |> update_socket()
 
     live_update(socket, :update_job, 100)
 
@@ -79,45 +60,23 @@ defmodule CrawlyUIWeb.JobLive do
   def handle_event("goto_page", %{"page" => page}, socket) do
     live_action = socket.assigns.live_action
 
-    if live_action == :spider do
-      spider = socket.assigns.spider
-
-      {:noreply,
-       push_redirect(socket,
-         to: CrawlyUIWeb.Router.Helpers.job_path(socket, live_action, page: page, spider: spider)
-       )}
-    else
-      {:noreply,
-       push_redirect(socket,
-         to: CrawlyUIWeb.Router.Helpers.job_path(socket, live_action, page: page)
-       )}
-    end
+    {:noreply,
+     push_redirect(socket,
+       to: CrawlyUIWeb.Router.Helpers.job_path(socket, live_action, page: page)
+     )}
   end
 
   def handle_event("show_spider", %{"spider" => spider}, socket) do
     {:noreply,
      push_redirect(socket,
-       to: CrawlyUIWeb.Router.Helpers.job_path(socket, :spider, spider: spider)
+       to: CrawlyUIWeb.Router.Helpers.spider_path(socket, :spider, spider: spider)
      )}
   end
 
   def handle_event("cancel", %{"job" => job_id}, socket) do
     job = job_id |> String.to_integer() |> Manager.get_job!()
 
-    state =
-      case SpiderManager.close_job_spider(job) do
-        {:ok, :stopped} ->
-          "cancelled"
-
-        {:error, :nodedown} ->
-          "node down"
-
-        _ ->
-          "stopped"
-      end
-
-    crawl_speed = Manager.crawl_speed(job)
-    Manager.update_job(job, %{state: state, crawl_speed: crawl_speed})
+    Manager.cancel_running_job(job)
 
     socket = update_socket(socket)
 
@@ -137,12 +96,12 @@ defmodule CrawlyUIWeb.JobLive do
 
   defp update_socket(socket) do
     page = socket.assigns.page
-    spider = socket.assigns.spider
 
     %{
       entries: rows,
+      page_number: page_number,
       total_pages: total_pages
-    } = list_jobs(socket.assigns.live_action, spider, page)
+    } = list_jobs(socket.assigns.live_action, page)
 
     case socket.assigns.live_action do
       :index ->
@@ -150,12 +109,13 @@ defmodule CrawlyUIWeb.JobLive do
 
         assign(socket,
           rows: rows,
+           page: page_number,
           total_pages: total_pages,
           recent_rows: recent_rows
         )
 
       _ ->
-        assign(socket, rows: rows, total_pages: total_pages)
+        assign(socket, rows: rows, total_pages: total_pages, page: page_number)
     end
   end
 
@@ -163,14 +123,8 @@ defmodule CrawlyUIWeb.JobLive do
     if connected?(socket), do: Process.send_after(self(), state, time)
   end
 
-  defp list_jobs(:index, _, page), do: Manager.list_running_jobs(page: page, page_size: 5)
-  defp list_jobs(:show, _, page), do: Manager.list_jobs(page: page)
-
-  defp list_jobs(:spider, spider, page) do
-    Manager.Job
-    |> where([j], j.spider == ^spider)
-    |> Manager.list_jobs(page: page)
-  end
+  defp list_jobs(:index, page), do: Manager.list_running_jobs(page: page, page_size: 5)
+  defp list_jobs(:show, page), do: Manager.list_jobs(page: page)
 
   defp get_recent_jobs() do
     Manager.Job

--- a/lib/crawly_ui_web/live/job_live.ex
+++ b/lib/crawly_ui_web/live/job_live.ex
@@ -109,7 +109,7 @@ defmodule CrawlyUIWeb.JobLive do
 
         assign(socket,
           rows: rows,
-           page: page_number,
+          page: page_number,
           total_pages: total_pages,
           recent_rows: recent_rows
         )

--- a/lib/crawly_ui_web/live/job_live.ex
+++ b/lib/crawly_ui_web/live/job_live.ex
@@ -103,6 +103,7 @@ defmodule CrawlyUIWeb.JobLive do
 
     case socket.assigns.live_action do
       :index ->
+        # Get also recent jobs on index page
         %{entries: recent_rows} = Manager.list_recent_jobs()
 
         assign(socket,

--- a/lib/crawly_ui_web/live/spider_live.ex
+++ b/lib/crawly_ui_web/live/spider_live.ex
@@ -1,0 +1,129 @@
+defmodule CrawlyUIWeb.SpiderLive do
+  use Phoenix.LiveView
+
+  alias CrawlyUI.Manager
+  alias CrawlyUI.SpiderManager
+
+  import Ecto.Query
+
+  def render(assigns) do
+    CrawlyUIWeb.JobView.render("spider.html", assigns)
+  end
+
+  def mount(params, _session, socket) do
+    spider = Map.get(params, "spider", nil)
+
+    socket =
+      case spider do
+        nil ->
+          nodes = Node.list()
+          available_spiders = Enum.map(nodes, fn node ->
+            spiders = SpiderManager.list_spiders(node)
+            {node, spiders}
+          end)
+
+
+          assign(socket, spider: spider, available_spiders: available_spiders)
+
+        spider ->
+          page = Map.get(params, "page", 1)
+
+          if connected?(socket), do: Process.send_after(self(), :update_spider, 100)
+
+          socket
+          |> assign(page: page, spider: spider)
+          |> update_socket()
+      end
+
+    {:ok, socket}
+  end
+
+  def handle_info(:update_spider, socket) do
+    socket = update_socket(socket)
+
+    if Enum.any?(socket.assigns.rows, &(&1.state == "running")) do
+      if connected?(socket), do: Process.send_after(self(), :update_spider, 100)
+    else
+      if connected?(socket), do: Process.send_after(self(), :update_spider, 1000)
+    end
+
+    {:noreply, socket}
+  end
+
+  def handle_event("goto_page", %{"page" => page}, socket) do
+    spider = socket.assigns.spider
+
+    {:noreply,
+     push_redirect(socket,
+       to: CrawlyUIWeb.Router.Helpers.spider_path(socket, :spider, page: page, spider: spider)
+     )}
+  end
+
+    def handle_event("show_spider", %{"spider" => spider}, socket) do
+    {:noreply,
+     push_redirect(socket,
+       to: CrawlyUIWeb.Router.Helpers.spider_path(socket, :spider, spider: spider)
+     )}
+  end
+
+  def handle_event("cancel", %{"job" => job_id}, socket) do
+    job = job_id |> String.to_integer() |> Manager.get_job!()
+
+    Manager.cancel_running_job(job)
+
+    socket = update_socket(socket)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("delete", %{"job" => job_id}, socket) do
+    job = job_id |> String.to_integer() |> Manager.get_job!()
+
+    job |> Manager.delete_all_job_items()
+    {:ok, _} = job |> Manager.delete_job()
+
+    socket = update_socket(socket)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("schedule_spider", %{"spider" => spider, "node" => node}, socket) do
+
+    case SpiderManager.start_spider(node, spider) do
+      {:ok, :started} ->
+        {:noreply,
+         socket
+         |> put_flash(
+           :info,
+           "Spider scheduled successfully. It might take a bit of time before items will appear here..."
+         )
+         |> redirect(to: CrawlyUIWeb.Router.Helpers.job_path(socket, :index))}
+
+      error ->
+        {:noreply,
+         socket
+         |> put_flash(:error, "#{inspect(error)}")
+         |> redirect(to: CrawlyUIWeb.Router.Helpers.spider_path(socket, :spider))}
+    end
+  end
+
+
+  defp update_socket(socket) do
+    page = socket.assigns.page
+    spider = socket.assigns.spider
+
+    %{
+      entries: rows,
+      page_number: page_number,
+      total_pages: total_pages
+    } = list_jobs(spider, page)
+
+    assign(socket, rows: rows, total_pages: total_pages, page: page_number)
+  end
+
+  defp list_jobs(spider, page) do
+    Manager.Job
+    |> where([j], j.spider == ^spider)
+    |> Manager.list_jobs(page: page)
+  end
+end

--- a/lib/crawly_ui_web/live/spider_live.ex
+++ b/lib/crawly_ui_web/live/spider_live.ex
@@ -39,7 +39,7 @@ defmodule CrawlyUIWeb.SpiderLive do
 
   def handle_info(:update_spiders, socket) do
     socket = update_spiders(socket)
-    if connected?(socket), do: Process.send_after(self(), :update_job, 1000)
+    if connected?(socket), do: Process.send_after(self(), :update_spiders, 1000)
     {:noreply, socket}
   end
 

--- a/lib/crawly_ui_web/live/spider_live.ex
+++ b/lib/crawly_ui_web/live/spider_live.ex
@@ -140,7 +140,7 @@ defmodule CrawlyUIWeb.SpiderLive do
   end
 
   defp list_jobs(spider, page) do
-    # For a spcific spider
+    # For a specific spider
     Manager.Job
     |> where([j], j.spider == ^spider)
     |> Manager.list_jobs(page: page)

--- a/lib/crawly_ui_web/router.ex
+++ b/lib/crawly_ui_web/router.ex
@@ -19,7 +19,8 @@ defmodule CrawlyUIWeb.Router do
 
     live "/", JobLive, :index
     live "/all", JobLive, :show
-    live "/spider", JobLive, :spider
+
+    live "/spider", SpiderLive, :spider
 
     live "/schedule", ScheduleLive, :pick_node
     live "/schedule/spider", ScheduleLive, :pick_spider

--- a/lib/crawly_ui_web/templates/job/spider.html.leex
+++ b/lib/crawly_ui_web/templates/job/spider.html.leex
@@ -1,19 +1,25 @@
 <%= if @spider == nil do %>
 <h1>Spiders</h1>
+<%= if @available_spiders != [] do %>
 <h2>Available for schedule</h2>
+<%= for {node, spiders} <- @available_spiders do%>
 <table>
- <%= for {node, spiders} <- @available_spiders do%>
    <tr>
       <th colspan="2"><%= node %></th>
    </tr>
    <%= for spider <- spiders do%>
    <tr>
-      <td><a href="#" phx-click=show_spider phx-value-spider=<%= spider %>><%= raw render_spider_name(spider) %></td>
-      <td><button phx-click="schedule_spider" phx-value-node=<%= node %> phx-value-spider=<%= spider%>> Schedule</button></td>
+      <td><a href="#" phx-click=show_spider phx-value-spider=<%= spider %>><%= raw render_spider_name(spider) %></a>
+      </td>
+      <td class="w"><button phx-click="schedule_spider" phx-value-node=<%= node %> phx-value-spider=<%= spider%>>
+            Schedule</button></td>
    </tr>
    <% end %>
-   <% end %>
 </table>
+<br>
+<br>
+<% end %>
+<% end %>
 
 <% else %>
 <h1>Spider</h1>

--- a/lib/crawly_ui_web/templates/job/spider.html.leex
+++ b/lib/crawly_ui_web/templates/job/spider.html.leex
@@ -1,5 +1,20 @@
 <%= if @spider == nil do %>
-<h1>Spider</h1>
+<h1>Spiders</h1>
+<h2>Available for schedule</h2>
+<table>
+ <%= for {node, spiders} <- @available_spiders do%>
+   <tr>
+      <th colspan="2"><%= node %></th>
+   </tr>
+   <%= for spider <- spiders do%>
+   <tr>
+      <td><a href="#" phx-click=show_spider phx-value-spider=<%= spider %>><%= raw render_spider_name(spider) %></td>
+      <td><button phx-click="schedule_spider" phx-value-node=<%= node %> phx-value-spider=<%= spider%>> Schedule</button></td>
+   </tr>
+   <% end %>
+   <% end %>
+</table>
+
 <% else %>
 <h1>Spider</h1>
 <h2><%= raw render_spider_name(@spider) %></h2>

--- a/test/crawly_ui_web/live/job_live_test.exs
+++ b/test/crawly_ui_web/live/job_live_test.exs
@@ -165,29 +165,17 @@ defmodule CrawlyUIWeb.JobLiveTest do
 
   test "cancel running job", %{conn: conn} do
     job_1 = insert_job(%{state: "running"})
-    job_2 = insert_job(%{state: "running"})
-    job_3 = insert_job(%{state: "running"})
 
     with_mock CrawlyUI.SpiderManager, [],
       close_job_spider: fn
         ^job_1 -> {:ok, :stopped}
-        ^job_2 -> {:error, :spider_not_running}
-        ^job_3 -> {:error, :nodedown}
       end do
       {:ok, view, _html} = live(conn, "/")
 
       assert render(view) =~
                "phx-click=\"cancel\" phx-value-job=\"#{job_1.id}\">Cancel"
 
-      assert render(view) =~
-               "phx-click=\"cancel\" phx-value-job=\"#{job_2.id}\">Cancel"
-
-      assert render(view) =~
-               "phx-click=\"cancel\" phx-value-job=\"#{job_3.id}\">Cancel"
-
       render_click(view, :cancel, %{"job" => Integer.to_string(job_1.id)})
-      render_click(view, :cancel, %{"job" => Integer.to_string(job_2.id)})
-      render_click(view, :cancel, %{"job" => Integer.to_string(job_3.id)})
 
       assert render(view) =~ "No jobs are currently running"
 
@@ -195,12 +183,6 @@ defmodule CrawlyUIWeb.JobLiveTest do
 
       assert render(view) =~
                "<td>cancelled</td><td>#{job_1.inserted_at}</td><td>0 items/min</td><td>0 min</td><td>"
-
-      assert render(view) =~
-               "<td>stopped</td><td>#{job_2.inserted_at}</td><td>0 items/min</td><td>0 min</td><td>"
-
-      assert render(view) =~
-               "<td>node down</td><td>#{job_3.inserted_at}</td><td>0 items/min</td><td>0 min</td><td>"
     end
   end
 

--- a/test/crawly_ui_web/live/job_live_test.exs
+++ b/test/crawly_ui_web/live/job_live_test.exs
@@ -32,22 +32,6 @@ defmodule CrawlyUIWeb.JobLiveTest do
     assert html =~ "Jobs"
   end
 
-  test "mount job view for showing all jobs of a spider", %{conn: conn} do
-    job_1 = insert_job(%{spider: "TestSpider"})
-    job_2 = insert_job(%{spider: "TestSpider"})
-    insert_job(%{spider: "OtherSpider"})
-
-    {:ok, _view, html} = live(conn, "/spider?spider=TestSpider")
-
-    assert html =~ "Spider"
-    assert html =~ "TestSpider"
-
-    assert html =~ "#{job_1.inserted_at}"
-    assert html =~ "#{job_2.inserted_at}"
-
-    refute html =~ "OtherSpider"
-  end
-
   test "redirect when click schedule", %{conn: conn} do
     {:ok, view, _html} = live(conn, "/")
     render_click(view, :schedule)
@@ -177,14 +161,6 @@ defmodule CrawlyUIWeb.JobLiveTest do
     assert view
            |> render_click(:goto_page, %{"page" => "2"})
            |> follow_redirect(conn, "/?page=2")
-  end
-
-  test "go to page for spider view", %{conn: conn} do
-    {:ok, view, _html} = live(conn, "/spider?spider=TestSpider")
-
-    assert view
-           |> render_click(:goto_page, %{"page" => "2"})
-           |> follow_redirect(conn, "/spider?page=2&spider=TestSpider")
   end
 
   test "cancel running job", %{conn: conn} do

--- a/test/crawly_ui_web/live/spider_live_test.exs
+++ b/test/crawly_ui_web/live/spider_live_test.exs
@@ -87,7 +87,6 @@ defmodule CrawlyUIWeb.SpiderLiveTest do
 
     Process.sleep(600)
     job_2 = insert_job(%{spider: "TestSpider", state: "cancelled"})
-    refute render(view) =~ "#{job_2.inserted_at}"
     Process.sleep(500)
 
     assert render(view) =~ "#{job_1.inserted_at}"

--- a/test/crawly_ui_web/live/spider_live_test.exs
+++ b/test/crawly_ui_web/live/spider_live_test.exs
@@ -1,0 +1,163 @@
+defmodule CrawlyUIWeb.SpiderLiveTest do
+  import CrawlyUI.DataCase
+
+  use CrawlyUIWeb.ConnCase
+  import Phoenix.LiveViewTest
+
+  import Mock
+
+  test "mount spider view to show all available spider", %{conn: conn} do
+    {:ok, _view, html} = live(conn, "/spider")
+
+    assert html =~ "Spiders"
+  end
+
+  test "mount spider view for showing all jobs of a spider", %{conn: conn} do
+    job_1 = insert_job(%{spider: "TestSpider"})
+    job_2 = insert_job(%{spider: "TestSpider"})
+    insert_job(%{spider: "OtherSpider"})
+
+    {:ok, _view, html} = live(conn, "/spider?spider=TestSpider")
+
+    assert html =~ "Spider"
+    assert html =~ "TestSpider"
+
+    assert html =~ "#{job_1.inserted_at}"
+    assert html =~ "#{job_2.inserted_at}"
+
+    refute html =~ "OtherSpider"
+  end
+
+  test "redicrect go to page for spider view", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/spider?spider=TestSpider")
+
+    assert view
+           |> render_click(:goto_page, %{"page" => "2"})
+           |> follow_redirect(conn, "/spider?page=2&spider=TestSpider")
+  end
+
+  test "redirect to a spider's jobs", %{conn: conn} do
+    {:ok, view, _html} = live(conn, "/spider")
+    render_click(view, :show_spider, %{"spider" => "TestSpider"})
+    assert_redirect(view, "/spider?spider=TestSpider")
+  end
+
+  test "update all spiders view every 1 second", %{conn: conn} do
+    with_mock CrawlyUI.SpiderManager, [], list_spiders: fn _ -> ["Crawly.TestSpider"] end do
+      # This is a bit weird test as it test the page is refreshed but I can't mock the node list and show the spiders, else we can mock connecting and disconnect to node and the spiders will show and dissappear
+      {:ok, view, _html} = live(conn, "/spider")
+
+      assert render(view) =~ "Spiders"
+      Process.sleep(1000)
+      assert render(view) =~ "Spiders"
+      Process.sleep(1000)
+      assert render(view) =~ "Spiders"
+    end
+  end
+
+  test "update job list when view jobs belong to a spider", %{conn: conn} do
+    job_1 = insert_job(%{spider: "TestSpider"})
+
+    {:ok, view, _html} = live(conn, "/spider?spider=TestSpider")
+
+    assert render(view) =~ "#{job_1.inserted_at}"
+
+    job_2 = insert_job(%{spider: "TestSpider"})
+
+    Process.sleep(100)
+
+    assert render(view) =~ "#{job_1.inserted_at}"
+    assert render(view) =~ "#{job_2.inserted_at}"
+
+    job_3 = insert_job(%{spider: "TestSpider"})
+
+    Process.sleep(100)
+
+    assert render(view) =~ "#{job_1.inserted_at}"
+    assert render(view) =~ "#{job_2.inserted_at}"
+    assert render(view) =~ "#{job_3.inserted_at}"
+  end
+
+  test "update a spider's jobs view when no jobs are running", %{conn: conn} do
+    job_1 = insert_job(%{spider: "TestSpider", state: "abandoned"})
+
+    {:ok, view, _html} = live(conn, "/spider?spider=TestSpider")
+
+    assert render(view) =~ "#{job_1.inserted_at}"
+
+    Process.sleep(600)
+    job_2 = insert_job(%{spider: "TestSpider", state: "cancelled"})
+    refute render(view) =~ "#{job_2.inserted_at}"
+    Process.sleep(500)
+
+    assert render(view) =~ "#{job_1.inserted_at}"
+    assert render(view) =~ "#{job_2.inserted_at}"
+  end
+
+  test "cancel running job", %{conn: conn} do
+    job_1 = insert_job(%{state: "running", spider: "TestSpider"})
+
+    with_mock CrawlyUI.SpiderManager, [],
+      close_job_spider: fn
+        ^job_1 -> {:ok, :stopped}
+      end do
+      {:ok, view, _html} = live(conn, "/spider?spider=TestSpider")
+
+      assert render(view) =~
+               "phx-click=\"cancel\" phx-value-job=\"#{job_1.id}\">Cancel"
+
+      render_click(view, :cancel, %{"job" => Integer.to_string(job_1.id)})
+
+      assert render(view) =~
+               "<td>cancelled</td><td>#{job_1.inserted_at}</td><td>0 items/min</td><td>0 min</td><td>"
+    end
+  end
+
+  test "delete job", %{conn: conn} do
+    job_1 = insert_job(%{state: "stopped", spider: "TestSpider"})
+
+    {:ok, view, _html} = live(conn, "/spider?spider=TestSpider")
+
+    assert render(view) =~
+             "phx-click=\"delete\" phx-value-job=\"#{job_1.id}\">Delete"
+
+    render_click(view, :delete, %{"job" => Integer.to_string(job_1.id)})
+
+    assert [] == CrawlyUI.Repo.all(CrawlyUI.Manager.Job)
+
+    refute render(view) =~
+             "phx-click=\"delete\" phx-value-job=\"#{job_1.id}\">Delete"
+  end
+
+  test "redirect to index when a spider job starts successfully", %{conn: conn} do
+    with_mock CrawlyUI.SpiderManager, [],
+      list_spiders: fn _ -> ["Crawly.TestSpider"] end,
+      start_spider: fn
+        "test", _ -> {:ok, :started}
+        "other_node", _ -> {:error, "Failed"}
+      end do
+      {:ok, view, _html} = live(conn, "/schedule/spider?node=test")
+      render_click(view, :schedule_spider, %{spider: "Crawly.TestSpider"})
+      flash = assert_redirect(view, "/")
+
+      assert flash["info"] ==
+               "Spider scheduled successfully. It might take a bit of time before items will appear here..."
+    end
+  end
+
+  test "redirect to schedule page when a spider job failed at starting", %{conn: conn} do
+    with_mock CrawlyUI.SpiderManager, [],
+      list_spiders: fn _ -> ["Crawly.TestSpider"] end,
+      start_spider: fn
+        "test", _ -> {:ok, :started}
+        "other_node", _ -> {:error, "Failed"}
+      end do
+      {:ok, view, _html} = live(conn, "/schedule/spider?node=other_node")
+      render_click(view, :schedule_spider, %{spider: "Crawly.TestSpider"})
+      flash = assert_redirect(view, "/schedule")
+
+      assert flash["error"] ==
+               "{:error, \"Failed\"}"
+    end
+  end
+end

--- a/test/crawly_ui_web/live/spider_live_test.exs
+++ b/test/crawly_ui_web/live/spider_live_test.exs
@@ -134,7 +134,6 @@ defmodule CrawlyUIWeb.SpiderLiveTest do
       list_spiders: fn _ -> ["Crawly.TestSpider"] end,
       start_spider: fn
         "test", _ -> {:ok, :started}
-        "other_node", _ -> {:error, "Failed"}
       end do
       {:ok, view, _html} = live(conn, "/schedule/spider?node=test")
       render_click(view, :schedule_spider, %{spider: "Crawly.TestSpider"})
@@ -149,7 +148,6 @@ defmodule CrawlyUIWeb.SpiderLiveTest do
     with_mock CrawlyUI.SpiderManager, [],
       list_spiders: fn _ -> ["Crawly.TestSpider"] end,
       start_spider: fn
-        "test", _ -> {:ok, :started}
         "other_node", _ -> {:error, "Failed"}
       end do
       {:ok, view, _html} = live(conn, "/schedule/spider?node=other_node")

--- a/test/crawly_ui_web/views/job_view_test.exs
+++ b/test/crawly_ui_web/views/job_view_test.exs
@@ -42,7 +42,7 @@ defmodule CrawlyUIWeb.JobViewTest do
              "1.5 hours"
   end
 
-  test "render spider name" do
+  test "render spider name with String input" do
     job_1 = insert_job(%{spider: "Elixir.Spider.Test"})
     job_2 = insert_job(%{spider: "Spider.Test"})
     job_3 = insert_job(%{spider: "Test"})
@@ -59,6 +59,19 @@ defmodule CrawlyUIWeb.JobViewTest do
     assert view =~ ">Test</a>"
     refute view =~ ">Spider.Test</a>"
     refute view =~ ">Elixir.Spider.Test</a>"
+  end
+
+  test "render spider name with atom input" do
+    view =
+      render_to_string(CrawlyUIWeb.JobView, "pick_spider.html",
+        node: "test@worker.com",
+        spiders: [:"Elixir.Spider.Test", :"Spider.Test", :Test],
+        error: nil
+      )
+
+    assert view =~ "<option value=\"Test\">Test</option>"
+    assert view =~ "<option value=\"Spider.Test\">Test</option>"
+    assert view =~ "<option value=\"Elixir.Spider.Test\">Test</option>"
   end
 
   test "render cancel button" do


### PR DESCRIPTION
<img width="1229" alt="Screenshot 2020-09-29 at 15 32 11" src="https://user-images.githubusercontent.com/7395378/94565044-fb3f0e00-0268-11eb-9d6a-791cf535b59a.png">


Address #24 - Can access with `/spider` there is no button to access from homepage yet, to be done in Menu bar Implementation

Moved functions like query recent job and cancel job to Manager instead of leaving it in the `LiveView` modules

Moved spider view to a separate `LiveView` module and template